### PR TITLE
Introduce `recv_blocking()` method on `PayloadReceiver`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,30 +62,24 @@ camera.load_context().unwrap();
 // Start streaming. Channel capacity is set to 3.
 let payload_rx = camera.start_streaming(3).unwrap();
 
-let mut payload_count = 0;
-while payload_count < 10 {
-    match payload_rx.try_recv() {
-        Ok(payload) => {
-            println!(
-                "payload received! block_id: {:?}, timestamp: {:?}",
-                payload.id(),
-                payload.timestamp()
-            );
-            if let Some(image_info) = payload.image_info() {
-                println!("{:?}\n", image_info);
-                let image = payload.image();
-                // do something with the image.
-                // ...
-            }
-            payload_count += 1;
-
-            // Send back payload to streaming loop to reuse the buffer. This is optional.
-            payload_rx.send_back(payload);
-        }
-        Err(_err) => {
-            continue;
-        }
+for _ in 0..10 {
+    let payload = payload_rx
+        .recv_blocking()
+        .expect("should receive a payload");
+    println!(
+        "payload received! block_id: {:?}, timestamp: {:?}",
+        payload.id(),
+        payload.timestamp()
+    );
+    if let Some(image_info) = payload.image_info() {
+        println!("{:?}\n", image_info);
+        let image = payload.image();
+        // do something with the image.
+        // ...
     }
+
+    // Send back payload to streaming loop to reuse the buffer. This is optional.
+    payload_rx.send_back(payload);
 }
 
 // Closes the camera.

--- a/cameleon/README.md
+++ b/cameleon/README.md
@@ -62,30 +62,24 @@ camera.load_context().unwrap();
 // Start streaming. Channel capacity is set to 3.
 let payload_rx = camera.start_streaming(3).unwrap();
 
-let mut payload_count = 0;
-while payload_count < 10 {
-    match payload_rx.try_recv() {
-        Ok(payload) => {
-            println!(
-                "payload received! block_id: {:?}, timestamp: {:?}",
-                payload.id(),
-                payload.timestamp()
-            );
-            if let Some(image_info) = payload.image_info() {
-                println!("{:?}\n", image_info);
-                let image = payload.image();
-                // do something with the image.
-                // ...
-            }
-            payload_count += 1;
-
-            // Send back payload to streaming loop to reuse the buffer. This is optional.
-            payload_rx.send_back(payload);
-        }
-        Err(_err) => {
-            continue;
-        }
+for _ in 0..10 {
+    let payload = payload_rx
+        .recv_blocking()
+        .expect("should receive a payload");
+    println!(
+        "payload received! block_id: {:?}, timestamp: {:?}",
+        payload.id(),
+        payload.timestamp()
+    );
+    if let Some(image_info) = payload.image_info() {
+        println!("{:?}\n", image_info);
+        let image = payload.image();
+        // do something with the image.
+        // ...
     }
+
+    // Send back payload to streaming loop to reuse the buffer. This is optional.
+    payload_rx.send_back(payload);
 }
 
 // Closes the camera.
@@ -188,4 +182,3 @@ To start developing, please refer to [CONTRIBUTING.md][contributing].
 This project is licenced under [MPL 2.0][license].
 
 [license]: https://github.com/cameleon-rs/cameleon/blob/main/LICENSE
-

--- a/cameleon/src/payload.rs
+++ b/cameleon/src/payload.rs
@@ -122,6 +122,12 @@ impl PayloadReceiver {
         self.rx.try_recv()?
     }
 
+    /// Receives [`Payload`] sent from the device.
+    /// If the channel is empty, this method blocks until the device produces it.
+    pub fn recv_blocking(&self) -> StreamResult<Payload> {
+        self.rx.recv_blocking()?
+    }
+
     /// Sends back [`Payload`] to the device to reuse already allocated `payload`.
     ///
     /// Sending back `payload` may improve performance of streaming, but not required to call this


### PR DESCRIPTION
<!--
Thank you for improving `Cameleon`!

Please fill out the checklist before opening the PR.
-->

- [x] Check `test_all.sh` is passed.
- ~Add `fix #{ISSUE_NUMBER}` if the corresponding issue exists.~
- [x] Fill out `## Changelog` section. If the change is for only internal use, please write `None` to the section.

<!--
We collect a changelog from a PR description, so please write a brief description about the change in the following `Changelog` section.
-->

In addition to the API changes, update readme and example to use the new method (current versiont does a busy-loop).

Best viewed with whitespace change ignored.

## Changelog

- `recv_blocking()` method was introduced on `PayloadReceiver`. It allows callers to wait for a frame without using futures.